### PR TITLE
requirements.txt revision

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -41,7 +41,6 @@ packaging==20.9
 pandas==1.2.4
 pip==21.0.1
 protobuf==3.15.8
-psycopg2==2.8.6
 pyasn1==0.4.8
 pyasn1-modules==0.2.7
 pycparser==2.20
@@ -60,8 +59,6 @@ requests==2.25.1
 requests-oauthlib==1.3.0
 rsa==4.7.2
 s3transfer==0.4.2
-scipy==1.6.3
-setuptools==49.6.0.post20210108
 six==1.15.0
 smart-open==5.0.0
 soupsieve==2.0.1
@@ -70,4 +67,5 @@ typing-extensions==3.7.4.3
 urllib3==1.26.3
 webencodings==0.5.1
 wheel==0.36.2
+multidict==5.1.0 
 yarl==1.6.3


### PR DESCRIPTION
psycopg2 version conflict. Corresponding index was deleted from requirements.txt 
Install the package manually ` pip3 install psycopg2-binary`